### PR TITLE
Fixed Beta detection, improved locale detection, Firebug 1.10.2

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,6 +128,7 @@ Previous updates removed from the README. Look at the file history to see them.
 ### Update: 31/08/2012
 - Fixed Firefox Beta detection, "beta" is now correctly detected as 16.0
 - Improved automatic locale detection for $LANG like "de_DE.UTF-8", $LANG setting is shown during detection
+- Updated Firebug to 1.10.2 for all Firefoxes using 1.10.0
 
 ### Update: 28/08/2012
 - Added Firefox 15.0

--- a/install-all-firefox.sh
+++ b/install-all-firefox.sh
@@ -234,9 +234,9 @@ get_associated_information(){
       short_name="fx14"
       nice_name="Firefox 14.0"
 
-      firebug_version="1.10.0"
+      firebug_version="1.10.2"
       firebug_root="http://getfirebug.com/releases/firebug/1.10/"
-      firebug_file="firebug-1.10.0.xpi"
+      firebug_file="firebug-1.10.2.xpi"
       ;;  
     15.0)
       ftp_root="ftp://ftp.mozilla.org/pub/mozilla.org/firefox/releases/15.0/"
@@ -247,9 +247,9 @@ get_associated_information(){
       short_name="fx15"
       nice_name="Firefox 15.0"
 
-      firebug_version="1.10.0"
+      firebug_version="1.10.2"
       firebug_root="http://getfirebug.com/releases/firebug/1.10/"
-      firebug_file="firebug-1.10.0.xpi"
+      firebug_file="firebug-1.10.2.xpi"
       ;;        
     beta)
       # This seems a bit flaky
@@ -274,9 +274,9 @@ get_associated_information(){
       short_name="fxb"
       nice_name="Firefox Beta"
 
-      firebug_version="1.10.0"
+      firebug_version="1.10.2"
       firebug_root="http://getfirebug.com/releases/firebug/1.10/"
-      firebug_file="firebug-1.10.0.xpi"
+      firebug_file="firebug-1.10.2.xpi"
       ;;
     aurora)
       release_type="aurora"
@@ -296,9 +296,9 @@ get_associated_information(){
       vol_name="Aurora"
       release_name="FirefoxAurora"
 
-      firebug_version="1.10.0"
+      firebug_version="1.10.2"
       firebug_root="http://getfirebug.com/releases/firebug/1.10/"
-      firebug_file="firebug-1.10.0.xpi"
+      firebug_file="firebug-1.10.2.xpi"
       ;;
     nightly)
       release_type="nightly"
@@ -318,9 +318,9 @@ get_associated_information(){
       vol_name="Nightly"
       release_name="FirefoxNightly"
 
-      firebug_version="1.10.0"
+      firebug_version="1.10.2"
       firebug_root="http://getfirebug.com/releases/firebug/1.10/"
-      firebug_file="firebug-1.10.0.xpi"
+      firebug_file="firebug-1.10.2.xpi"
       ;;
     ux)
       release_type="ux"
@@ -340,9 +340,9 @@ get_associated_information(){
       vol_name="UX"
       release_name="FirefoxUX"
 
-      firebug_version="1.10.0"
+      firebug_version="1.10.2"
       firebug_root="http://getfirebug.com/releases/firebug/1.10/"
-      firebug_file="firebug-1.10.0.xpi"
+      firebug_file="firebug-1.10.2.xpi"
       ;;
     *)
       error "  Invalid version specified!\n\n  Please choose one of:\n  all all_past all_future current $default_versions\n\n"


### PR DESCRIPTION
Each change separated in its own commit:
- Fixed Firefox Beta detection, "beta" is now correctly detected as 16.0
- Improved automatic locale detection for $LANG like "de_DE.UTF-8", $LANG setting is shown during detection
- Updated Firebug to 1.10.2 for all Firefoxes using 1.10.0

Would be glad if you could merge them.
