### PR TITLE
Fallback to a valid system locale if country code is not supported

### DIFF
--- a/install-all-firefox.sh
+++ b/install-all-firefox.sh
@@ -928,8 +928,18 @@ fi
 get_locale() {
   all_locales=" af ar be bg ca cs da de el en-GB en-US es-AR es-ES eu fi fr fy-NL ga-IE he hu it ja-JP-mac ko ku lt mk mn nb-NO nl nn-NO pa-IN pl pt-BR pt-PT ro ru sk sl sv-SE tr uk zh-CN zh-TW "
 
-  cleaned_system_locale=`echo ${LANG/_/-} | sed 's/\..*//'`
+  # ex: "fr-FR.UTF-8" => "fr-FR"
   cleaned_specified_locale=`echo ${specified_locale/_/-} | sed 's/\..*//'`
+  cleaned_system_locale=`echo ${LANG/_/-} | sed 's/\..*//'`
+
+  # ex: "fr-FR" => "fr"
+  cleaned_system_locale_short=`echo $cleaned_system_locale | sed 's/-.*//'`
+
+  if [[ $all_locales != *" $cleaned_system_locale "* && $all_locales == *" $cleaned_system_locale_short "* ]]; then
+    echo "Your system locale \"$cleaned_system_locale\" is not available, but \"$cleaned_system_locale_short\" is!"
+    echo "We'll use \"$cleaned_system_locale_short\" as the default locale if you've not specified a valid locale."
+    cleaned_system_locale=$cleaned_system_locale_short
+  fi
 
   if [ -n $specified_locale ]; then
     if [[ $all_locales != *" $cleaned_specified_locale "* ]]; then


### PR DESCRIPTION
The typical use case is when your LANG env variable contains a "country-based" locale (ex: "fr-FR") which is not available for download on the FTP.

We could automatically fall back on the basic locale (with no country subtag) if available for download (ex: "fr"). 

``` bash
$ echo $LANG 
# fr-FR.UTF-8

$ ./firefoxes.sh 31
# Your system locale "fr-FR" is not available, but "fr" is!
# We'll use "fr" as the default locale if you've not specified a valid locale.
# "" was not found in our list of valid locales.
# We're using fr as your locale.
# [...]
```

This makes the script work out of the box for some people without the need to explicitly pass a locale.
