### PR TITLE
Make multiline echo compatible with shells other than bash (zsh, sh...)

### DIFF
--- a/firefoxes.sh
+++ b/firefoxes.sh
@@ -12,7 +12,8 @@ main () {
     local remote_script_md5=""
 
     if [[ "$(uname -s)" != "Darwin" ]]; then
-        echo -e "This script is designed to be used on OS X only.\nExiting..."
+        echo "This script is designed to be used on OS X only."
+        echo "Exiting..."
         exit 1
     fi
 

--- a/install-all-firefox.sh
+++ b/install-all-firefox.sh
@@ -933,7 +933,7 @@ get_locale() {
 
   if [ -n $specified_locale ]; then
     if [[ $all_locales != *" $cleaned_specified_locale "* ]]; then
-        echo -e "\"${cleaned_specified_locale}\" was not found in our list of valid locales."
+        echo "\"${cleaned_specified_locale}\" was not found in our list of valid locales."
         locale=$cleaned_system_locale
 
     else
@@ -945,8 +945,10 @@ get_locale() {
 
   echo "We're using ${locale} as your locale."
 
-  echo -e "If this is wrong, use './firefoxes.sh [version] [locale]' to specify the locale.\n"
-  echo -e "The valid locales are: \n ${all_locales}"
+  echo "If this is wrong, use './firefoxes.sh [version] [locale]' to specify the locale."
+  echo ""
+  echo "The valid locales are:"
+  echo " ${all_locales}"
 }
 
 clean_up() {


### PR DESCRIPTION
The syntax `echo -e "Multi\nLine..."` is somewhat bash-specific. 

I know the docs explicitly state that the scripts should be used with bash, but with little effort we can improve the output of the scripts for the people using it with other shells.

Example:

``` bash
# before
zsh-$>  ./firefoxes.sh 31
# -e "" was not found in our list of valid locales.
# We're using en-US as your locale.
# -e If this is wrong, use './firefoxes.sh [version] [locale]' to specify the locale.
# 
# -e The valid locales are:
#   af ar be bg ca cs da de el en-GB en-US es-AR es-ES eu fi fr fy-NL ga-IE he hu it ja-JP-mac ko ku lt mk mn nb-NO nl nn-NO pa-IN pl pt-BR pt-PT ro ru sk sl sv-SE tr uk zh-CN zh-TW 

# after
zsh-$>  ./firefoxes.sh 31
# "" was not found in our list of valid locales.
# We're using en-US as your locale.
# If this is wrong, use './firefoxes.sh [version] [locale]' to specify the locale.
# 
# The valid locales are:
#   af ar be bg ca cs da de el en-GB en-US es-AR es-ES eu fi fr fy-NL ga-IE he hu it ja-JP-mac ko ku lt mk mn nb-NO nl nn-NO pa-IN pl pt-BR pt-PT ro ru sk sl sv-SE tr uk zh-CN zh-TW 
```
