### PR TITLE
redircted en-AU locale to en-US

### DIFF
--- a/install-all-firefox.sh
+++ b/install-all-firefox.sh
@@ -935,6 +935,11 @@ get_locale() {
   # ex: "fr-FR" => "fr"
   cleaned_system_locale_short=`echo $cleaned_system_locale | sed 's/-.*//'`
 
+  if [[ $cleaned_system_locale == 'en-AU' ]]; then
+    echo "Your system locale is set to en-AU. As there is no en-AU localization available for Firefox, en-US has been used instead."
+    cleaned_system_locale='en-US'
+  fi
+
   if [[ $all_locales != *" $cleaned_system_locale "* && $all_locales == *" $cleaned_system_locale_short "* ]]; then
     echo "Your system locale \"$cleaned_system_locale\" is not available, but \"$cleaned_system_locale_short\" is!"
     echo "We'll use \"$cleaned_system_locale_short\" as the default locale if you've not specified a valid locale."


### PR DESCRIPTION
Hi,
As there is no en-AU localisation for Firefox, attempting to download any version of Firefox without specifying the localisation ends in failure.
I propose that en-AU redirects to en-US (the nearest equivalent locale).
I'm pretty new to doing pull requests so pre-apologies if this is the wrong way to do it or something.
Also incidentally when it can't find a locale it doesn't fail very gracefully. 
It attempts to create a profile and believes it succeeds. Hitting 'y' to install firebug then causes it to hang.
Cheers,
Callum.
