### PR TITLE
Small fix and change for alternate locales

### DIFF
--- a/install-all-firefox.sh
+++ b/install-all-firefox.sh
@@ -942,7 +942,7 @@ get_locale() {
 
     # Will make something more scalable if needed later
     # But for now, we make these locales use en-US
-    if [[ $cleaned_system_locale == 'en-AU' || $cleaned_sysem_locale == 'en-CA' ]]; then
+    if [[ $cleaned_system_locale == 'en-AU' || $cleaned_system_locale == 'en-CA' ]]; then
         echo "Your system locale is set to ${cleaned_system_locale}. As there is no ${cleaned_system_locale} localization available for Firefox, en-US has been used instead."
         cleaned_system_locale='en-US'
     fi
@@ -953,7 +953,7 @@ get_locale() {
         cleaned_system_locale=$cleaned_system_locale_short
     fi
 
-    if [ -n $specified_locale ]; then
+    if [[ -n $specified_locale ]]; then
         if [[ $all_locales != *" $cleaned_specified_locale "* ]]; then
             echo "\"${cleaned_specified_locale}\" was not found in our list of valid locales."
             locale=$cleaned_system_locale


### PR DESCRIPTION
There are two small changes, the first of which (on line 945) is required - `$cleaned_sysem_locale` becoming `$cleaned_system_locale` - whereas the second (on line 956) is a workaround for showing `"" was not found in our list of valid locales.` when none is specified. I'm proposing that only because it confused me when debugging my locale issues.
