### PR TITLE
Fix nightly download with updated sed pattern

### DIFF
--- a/install-all-firefox.sh
+++ b/install-all-firefox.sh
@@ -667,7 +667,7 @@ get_associated_information(){
             future="true"
             ftp_root="ftp://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/"
             if [[ $versions != 'status' ]]; then
-                dmg_file=$(curl --progress-bar -L ${ftp_root} | grep ".mac.dmg$" | tail -1 | sed "s/^.\{56\}//")
+                dmg_file=$(curl --progress-bar -L ${ftp_root} | grep ".mac.dmg$" | tail -1 | sed "s/^.* \(".*"$\)/\1/")
                 sum_file=$(echo ${dmg_file} | sed "s/\.dmg/\.checksums/")
                 sum_file_type="sha512"
             fi


### PR DESCRIPTION
Fixes #56

Instead of counting 56 characters from the left to get the filename, this gets the last column of text (as separated by whitespace) in the output.

I tried to apply it to the others but they are all fragile in their own way and funny enough they weren't even broken.